### PR TITLE
remove bin/setup in favor of bundle install

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ packer.build(debug: true)
 
 ## Development
 
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment. Run `bundle exec pack_rb` to use the gem in this directory, ignoring other installed copies of this gem.
+After checking out the repo, run `bundle install` to install dependencies. Then, run `bundle exec rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment. Run `bundle exec pack_rb` to use the gem in this directory, ignoring other installed copies of this gem.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 

--- a/bin/setup
+++ b/bin/setup
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-IFS=$'\n\t'
-set -vx
-
-bundle install
-
-# Do any other automated setup that you need to do here


### PR DESCRIPTION
Maybe I'm missing the logic behind this, but `bundle install` is a pretty well-known and understood way of setting up a Ruby development environment. I've never seen anyone wrap it in an executable before, and when I read the instructions, my first reaction was, "what's this aribtrary script they want me to run on my machine, what does it do, and why don't they... oh. it just wraps 'bundle install'."

I'm also a bit confused by `bin/console`, as opposed to simply telling people to use `bundle exec irb -r pack_rb` (which I think is more clear about what's actually happening).
