### PR TITLE
fixes #2 and #3 - stream command output as it runs, and return stdout, stderr and exit code

### DIFF
--- a/lib/pack_rb/executor.rb
+++ b/lib/pack_rb/executor.rb
@@ -1,0 +1,47 @@
+require 'open3'
+
+module PackRb
+  class Executor
+    # popen3 wrapper to simultaneously stream command output to the
+    # appropriate file descriptor, and capture it.
+    #
+    # @param cmd [String] command to run
+    # @param tpl [String] the template content
+    # @return [Array] - stdout [String], stderr [String], exit code [Fixnum]
+    def self.run_cmd_stream_output(cmd, tpl)
+      all_out = ''
+      all_err = ''
+      exit_status = nil
+      Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thread|
+        stdin.write(tpl)
+        stdin.close_write
+        begin
+          files = [stdout, stderr]
+          until files.find { |f| !f.eof }.nil?
+            ready = IO.select(files)
+            next unless ready
+            readable = ready[0]
+            readable.each do |f|
+              begin
+                data = f.read_nonblock(512)
+                if f.fileno == stdout.fileno
+                  puts data
+                  all_out << data
+                else
+                  STDERR.puts data
+                  all_err << data
+                end
+              rescue EOFError
+                nil
+              end
+            end
+          end
+        rescue IOError => e
+          STDERR.puts "IOError: #{e}"
+        end
+        exit_status = wait_thread.value.exitstatus
+      end
+      [all_out, all_err, exit_status]
+    end
+  end
+end

--- a/lib/pack_rb/sub_commands.rb
+++ b/lib/pack_rb/sub_commands.rb
@@ -1,5 +1,4 @@
-require 'open3'
-
+require 'pack_rb/executor'
 require 'pack_rb/sub_commands/build'
 require 'pack_rb/sub_commands/inspect'
 require 'pack_rb/sub_commands/validate'
@@ -10,7 +9,7 @@ module PackRb
     include PackRb::SubCommands::Inspect
     include PackRb::SubCommands::Validate
 
-    # Execute a Packer command via {#run_cmd_stream_output}
+    # Execute a Packer command via {PackRb::Executor.run_cmd_stream_output}
     #
     # @param opts [Hash] options passed to the Packer class
     #
@@ -19,49 +18,7 @@ module PackRb
       cmd = opts[:cmd]
       tpl = opts[:tpl]
 
-      run_cmd_stream_output("#{cmd} -", tpl)
-    end
-
-    # popen3 wrapper to simultaneously stream command output to the
-    # appropriate file descriptor, and capture it.
-    #
-    # @param cmd [String] command to run
-    # @param tpl [String] the template content
-    # @return [Array] - stdout [String], stderr [String], exit code [Fixnum]
-    def run_cmd_stream_output(cmd, tpl)
-      all_out = ''
-      all_err = ''
-      exit_status = nil
-      Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thread|
-        stdin.write(tpl)
-        stdin.close_write
-        begin
-          files = [stdout, stderr]
-          until files.find { |f| !f.eof }.nil?
-            ready = IO.select(files)
-            next unless ready
-            readable = ready[0]
-            readable.each do |f|
-              begin
-                data = f.read_nonblock(512)
-                if f.fileno == stdout.fileno
-                  puts data
-                  all_out << data
-                else
-                  STDERR.puts data
-                  all_err << data
-                end
-              rescue EOFError
-                nil
-              end
-            end
-          end
-        rescue IOError => e
-          STDERR.puts "IOError: #{e}"
-        end
-        exit_status = wait_thread.value.exitstatus
-      end
-      [all_out, all_err, exit_status]
+      PackRb::Executor.run_cmd_stream_output("#{cmd} -", tpl)
     end
   end
 end

--- a/lib/pack_rb/sub_commands.rb
+++ b/lib/pack_rb/sub_commands.rb
@@ -10,7 +10,7 @@ module PackRb
     include PackRb::SubCommands::Inspect
     include PackRb::SubCommands::Validate
 
-    # Execute a Packer command.
+    # Execute a Packer command via {#run_cmd_stream_output}
     #
     # @param opts [Hash] options passed to the Packer class
     #

--- a/lib/pack_rb/sub_commands.rb
+++ b/lib/pack_rb/sub_commands.rb
@@ -19,10 +19,7 @@ module PackRb
       cmd = opts[:cmd]
       tpl = opts[:tpl]
 
-      out, err, status = run_cmd_stream_output("#{cmd} -", tpl)
-      # rubocop:disable Style/RedundantReturn
-      return [out, err, status]
-      # rubocop:enable Style/RedundantReturn
+      run_cmd_stream_output("#{cmd} -", tpl)
     end
 
     # popen3 wrapper to simultaneously stream command output to the

--- a/lib/pack_rb/sub_commands.rb
+++ b/lib/pack_rb/sub_commands.rb
@@ -61,9 +61,7 @@ module PackRb
         end
         exit_status = wait_thread.value.exitstatus
       end
-      # rubocop:disable Style/RedundantReturn
-      return all_out, all_err, exit_status
-      # rubocop:enable Style/RedundantReturn
+      [all_out, all_err, exit_status]
     end
   end
 end

--- a/lib/pack_rb/sub_commands.rb
+++ b/lib/pack_rb/sub_commands.rb
@@ -10,16 +10,63 @@ module PackRb
     include PackRb::SubCommands::Inspect
     include PackRb::SubCommands::Validate
 
+    # Execute a Packer command.
+    #
+    # @param opts [Hash] options passed to the Packer class
+    #
+    # @return [Array] - stdout [String], stderr [String], exit code [Fixnum]
     def execute(opts)
       cmd = opts[:cmd]
       tpl = opts[:tpl]
 
-      out, err, status = Open3.capture3("#{cmd} -", stdin_data: tpl)
+      out, err, status = run_cmd_stream_output("#{cmd} -", tpl)
+      # rubocop:disable Style/RedundantReturn
+      return [out, err, status]
+      # rubocop:enable Style/RedundantReturn
+    end
 
-      if status.exitstatus != 0
-        puts out if out
-        puts err if err
+    # popen3 wrapper to simultaneously stream command output to the
+    # appropriate file descriptor, and capture it.
+    #
+    # @param cmd [String] command to run
+    # @param tpl [String] the template content
+    # @return [Array] - stdout [String], stderr [String], exit code [Fixnum]
+    def run_cmd_stream_output(cmd, tpl)
+      all_out = ''
+      all_err = ''
+      exit_status = nil
+      Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thread|
+        stdin.write(tpl)
+        stdin.close_write
+        begin
+          files = [stdout, stderr]
+          until files.find { |f| !f.eof }.nil?
+            ready = IO.select(files)
+            next unless ready
+            readable = ready[0]
+            readable.each do |f|
+              begin
+                data = f.read_nonblock(512)
+                if f.fileno == stdout.fileno
+                  puts data
+                  all_out << data
+                else
+                  STDERR.puts data
+                  all_err << data
+                end
+              rescue EOFError
+                nil
+              end
+            end
+          end
+        rescue IOError => e
+          STDERR.puts "IOError: #{e}"
+        end
+        exit_status = wait_thread.value.exitstatus
       end
+      # rubocop:disable Style/RedundantReturn
+      return all_out, all_err, exit_status
+      # rubocop:enable Style/RedundantReturn
     end
   end
 end

--- a/lib/pack_rb/version.rb
+++ b/lib/pack_rb/version.rb
@@ -1,3 +1,3 @@
 module PackRb
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/spec/pack_rb/executor_spec.rb
+++ b/spec/pack_rb/executor_spec.rb
@@ -1,0 +1,119 @@
+require 'spec_helper'
+require 'pack_rb/sub_commands'
+
+describe PackRb::Executor do
+  describe '#run_cmd_stream_output' do
+    let(:tpl) { 'template_data' }
+    # test logic for this was inspired by:
+    # http://rxr.whitequark.org/rubinius/source/spec/ruby/core/io/select_spec.rb
+    before :each do
+      @outpipe_r, @outpipe_w = IO.pipe
+      @errpipe_r, @errpipe_w = IO.pipe
+      @inpipe_r, @inpipe_w = IO.pipe
+    end
+    after :each do
+      @outpipe_r.close unless @outpipe_r.closed?
+      @outpipe_w.close unless @outpipe_w.closed?
+      @errpipe_r.close unless @errpipe_r.closed?
+      @errpipe_w.close unless @errpipe_w.closed?
+      @inpipe_r.close unless @inpipe_r.closed?
+      @inpipe_w.close unless @inpipe_w.closed?
+    end
+    context 'success' do
+      it 'prints and returns STDOUT' do
+        dbl_wait_thread = double(Thread)
+        @errpipe_w.close
+        @outpipe_w.write('mystdout')
+        @outpipe_w.close
+        es = double('exitstatus', exitstatus: 0)
+        allow(dbl_wait_thread).to receive(:value).and_return(es)
+        allow(Open3).to receive(:popen3).and_yield(
+          @inpipe_w, @outpipe_r, @errpipe_r, dbl_wait_thread
+        )
+
+        expect(Open3).to receive(:popen3).once.with('foo bar')
+        expect(STDOUT).to receive(:puts).once.with('mystdout')
+        expect(PackRb::Executor.run_cmd_stream_output('foo bar', tpl))
+          .to eq(['mystdout', '', 0])
+        expect(@inpipe_r.read).to eq(tpl)
+      end
+      it 'prints and returns STDERR' do
+        dbl_wait_thread = double(Thread)
+        @errpipe_w.write('mystderr')
+        @errpipe_w.close
+        @outpipe_w.close
+        es = double('exitstatus', exitstatus: 0)
+        allow(dbl_wait_thread).to receive(:value).and_return(es)
+        allow(Open3).to receive(:popen3).and_yield(
+          @inpipe_w, @outpipe_r, @errpipe_r, dbl_wait_thread
+        )
+
+        expect(Open3).to receive(:popen3).once.with('foo bar')
+        expect(STDERR).to receive(:puts).once.with('mystderr')
+        expect(PackRb::Executor.run_cmd_stream_output('foo bar', tpl))
+          .to eq(['', 'mystderr', 0])
+        expect(@inpipe_r.read).to eq(tpl)
+      end
+      it 'prints and returns both STDOUT and STDERR' do
+        dbl_wait_thread = double(Thread)
+        @errpipe_w.write('STDERR')
+        @errpipe_w.close
+        @outpipe_w.write('mystdout')
+        @outpipe_w.close
+        es = double('exitstatus', exitstatus: 0)
+        allow(dbl_wait_thread).to receive(:value).and_return(es)
+        allow(Open3).to receive(:popen3).and_yield(
+          @inpipe_w, @outpipe_r, @errpipe_r, dbl_wait_thread
+        )
+
+        expect(Open3).to receive(:popen3).once.with('foo bar')
+        expect(STDOUT).to receive(:puts).once.with('mystdout')
+        expect(STDERR).to receive(:puts).once.with('STDERR')
+        expect(PackRb::Executor.run_cmd_stream_output('foo bar', tpl))
+          .to eq(['mystdout', 'STDERR', 0])
+        expect(@inpipe_r.read).to eq(tpl)
+      end
+    end
+    context 'IOError' do
+      it 'handles IOErrors gracefully' do
+        dbl_wait_thread = double(Thread)
+        @errpipe_w.close
+        @outpipe_w.write('mystdout')
+        @outpipe_w.close
+        @errpipe_r.close
+        es = double('exitstatus', exitstatus: 0)
+        allow(dbl_wait_thread).to receive(:value).and_return(es)
+        allow(Open3).to receive(:popen3).and_yield(
+          @inpipe_w, @outpipe_r, @errpipe_r, dbl_wait_thread
+        )
+
+        expect(Open3).to receive(:popen3).once.with('foo bar')
+        expect(STDERR).to receive(:puts).once.with('IOError: closed stream')
+        expect(PackRb::Executor.run_cmd_stream_output('foo bar', tpl))
+          .to eq(['', '', 0])
+        expect(@inpipe_r.read).to eq(tpl)
+      end
+    end
+    context 'failure' do
+      it 'returns the non-zero exit code' do
+        dbl_wait_thread = double(Thread)
+        @errpipe_w.write('STDERR')
+        @errpipe_w.close
+        @outpipe_w.write('mystdout')
+        @outpipe_w.close
+        es = double('exitstatus', exitstatus: 23)
+        allow(dbl_wait_thread).to receive(:value).and_return(es)
+        allow(Open3).to receive(:popen3).and_yield(
+          @inpipe_w, @outpipe_r, @errpipe_r, dbl_wait_thread
+        )
+
+        expect(Open3).to receive(:popen3).once.with('foo bar')
+        expect(STDOUT).to receive(:puts).once.with('mystdout')
+        expect(STDERR).to receive(:puts).once.with('STDERR')
+        expect(PackRb::Executor.run_cmd_stream_output('foo bar', tpl))
+          .to eq(['mystdout', 'STDERR', 23])
+        expect(@inpipe_r.read).to eq(tpl)
+      end
+    end
+  end
+end

--- a/spec/pack_rb/sub_commands_spec.rb
+++ b/spec/pack_rb/sub_commands_spec.rb
@@ -26,8 +26,6 @@ module PackRb
       it 'returns the stdout, stderr and exit code' do
         allow(subject).to receive(:run_cmd_stream_output)
           .and_return(['out', 'err', 0])
-        expect(subject).to receive(:run_cmd_stream_output).once
-          .with("#{cmd} -", json)
         expect(subject.execute(cmd: cmd, tpl: json)).to eq(['out', 'err', 0])
       end
     end

--- a/spec/pack_rb/sub_commands_spec.rb
+++ b/spec/pack_rb/sub_commands_spec.rb
@@ -16,134 +16,17 @@ module PackRb
       let(:json) { %Q{{"variables":{"foo":"bar"}}} }
 
       it 'runs the provided command using run_cmd_stream_output' do
-        allow(subject).to receive(:run_cmd_stream_output)
+        allow(PackRb::Executor).to receive(:run_cmd_stream_output)
           .and_return(['out', 'err', 0])
-        expect(subject).to receive(:run_cmd_stream_output).once
+        expect(PackRb::Executor).to receive(:run_cmd_stream_output).once
           .with("#{cmd} -", json)
         subject.execute(cmd: cmd, tpl: json)
       end
 
       it 'returns the stdout, stderr and exit code' do
-        allow(subject).to receive(:run_cmd_stream_output)
+        allow(PackRb::Executor).to receive(:run_cmd_stream_output)
           .and_return(['out', 'err', 0])
         expect(subject.execute(cmd: cmd, tpl: json)).to eq(['out', 'err', 0])
-      end
-    end
-    describe '#run_cmd_stream_output' do
-      subject do
-        SubCommands.new
-      end
-      let(:tpl) { 'template_data' }
-      # test logic for this was inspired by:
-      # http://rxr.whitequark.org/rubinius/source/spec/ruby/core/io/select_spec.rb
-      before :each do
-        @outpipe_r, @outpipe_w = IO.pipe
-        @errpipe_r, @errpipe_w = IO.pipe
-        @inpipe_r, @inpipe_w = IO.pipe
-      end
-      after :each do
-        @outpipe_r.close unless @outpipe_r.closed?
-        @outpipe_w.close unless @outpipe_w.closed?
-        @errpipe_r.close unless @errpipe_r.closed?
-        @errpipe_w.close unless @errpipe_w.closed?
-        @inpipe_r.close unless @inpipe_r.closed?
-        @inpipe_w.close unless @inpipe_w.closed?
-      end
-      context 'success' do
-        it 'prints and returns STDOUT' do
-          dbl_wait_thread = double(Thread)
-          @errpipe_w.close
-          @outpipe_w.write('mystdout')
-          @outpipe_w.close
-          es = double('exitstatus', exitstatus: 0)
-          allow(dbl_wait_thread).to receive(:value).and_return(es)
-          allow(Open3).to receive(:popen3).and_yield(
-            @inpipe_w, @outpipe_r, @errpipe_r, dbl_wait_thread
-          )
-
-          expect(Open3).to receive(:popen3).once.with('foo bar')
-          expect(STDOUT).to receive(:puts).once.with('mystdout')
-          expect(subject.run_cmd_stream_output('foo bar', tpl))
-            .to eq(['mystdout', '', 0])
-          expect(@inpipe_r.read).to eq(tpl)
-        end
-        it 'prints and returns STDERR' do
-          dbl_wait_thread = double(Thread)
-          @errpipe_w.write('mystderr')
-          @errpipe_w.close
-          @outpipe_w.close
-          es = double('exitstatus', exitstatus: 0)
-          allow(dbl_wait_thread).to receive(:value).and_return(es)
-          allow(Open3).to receive(:popen3).and_yield(
-            @inpipe_w, @outpipe_r, @errpipe_r, dbl_wait_thread
-          )
-
-          expect(Open3).to receive(:popen3).once.with('foo bar')
-          expect(STDERR).to receive(:puts).once.with('mystderr')
-          expect(subject.run_cmd_stream_output('foo bar', tpl))
-            .to eq(['', 'mystderr', 0])
-          expect(@inpipe_r.read).to eq(tpl)
-        end
-        it 'prints and returns both STDOUT and STDERR' do
-          dbl_wait_thread = double(Thread)
-          @errpipe_w.write('STDERR')
-          @errpipe_w.close
-          @outpipe_w.write('mystdout')
-          @outpipe_w.close
-          es = double('exitstatus', exitstatus: 0)
-          allow(dbl_wait_thread).to receive(:value).and_return(es)
-          allow(Open3).to receive(:popen3).and_yield(
-            @inpipe_w, @outpipe_r, @errpipe_r, dbl_wait_thread
-          )
-
-          expect(Open3).to receive(:popen3).once.with('foo bar')
-          expect(STDOUT).to receive(:puts).once.with('mystdout')
-          expect(STDERR).to receive(:puts).once.with('STDERR')
-          expect(subject.run_cmd_stream_output('foo bar', tpl))
-            .to eq(['mystdout', 'STDERR', 0])
-          expect(@inpipe_r.read).to eq(tpl)
-        end
-      end
-      context 'IOError' do
-        it 'handles IOErrors gracefully' do
-          dbl_wait_thread = double(Thread)
-          @errpipe_w.close
-          @outpipe_w.write('mystdout')
-          @outpipe_w.close
-          @errpipe_r.close
-          es = double('exitstatus', exitstatus: 0)
-          allow(dbl_wait_thread).to receive(:value).and_return(es)
-          allow(Open3).to receive(:popen3).and_yield(
-            @inpipe_w, @outpipe_r, @errpipe_r, dbl_wait_thread
-          )
-
-          expect(Open3).to receive(:popen3).once.with('foo bar')
-          expect(STDERR).to receive(:puts).once.with('IOError: closed stream')
-          expect(subject.run_cmd_stream_output('foo bar', tpl))
-            .to eq(['', '', 0])
-          expect(@inpipe_r.read).to eq(tpl)
-        end
-      end
-      context 'failure' do
-        it 'returns the non-zero exit code' do
-          dbl_wait_thread = double(Thread)
-          @errpipe_w.write('STDERR')
-          @errpipe_w.close
-          @outpipe_w.write('mystdout')
-          @outpipe_w.close
-          es = double('exitstatus', exitstatus: 23)
-          allow(dbl_wait_thread).to receive(:value).and_return(es)
-          allow(Open3).to receive(:popen3).and_yield(
-            @inpipe_w, @outpipe_r, @errpipe_r, dbl_wait_thread
-          )
-
-          expect(Open3).to receive(:popen3).once.with('foo bar')
-          expect(STDOUT).to receive(:puts).once.with('mystdout')
-          expect(STDERR).to receive(:puts).once.with('STDERR')
-          expect(subject.run_cmd_stream_output('foo bar', tpl))
-            .to eq(['mystdout', 'STDERR', 23])
-          expect(@inpipe_r.read).to eq(tpl)
-        end
       end
     end
   end


### PR DESCRIPTION
This uses some code I wrote for an internal gem and very slightly modified. When executing commands, it will now stream the output as well as return an Array of [STDOUT, STDERR, exit_status].

I've tried this branch from a project's Rakefile that I'm working on, and these changes seem to function as intended.
