### PR TITLE
replace run_cmd_stream_output implementation with one that combines STDOUT and STDERR but isn't vulnerable to deadlocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,13 @@ packer = PackRb::Packer.new(tpl: 'config/template.json', machine_readable: true)
 packer.build(debug: true)
 ```
 
+### Output
+
+The Packer methods will return a 2-item array:
+
+* String, combined STDOUT and STDERR of the ``packer`` process
+* Fixnum, ``packer`` process exit code
+
 ### Streaming Output
 
 If you wish to have STDOUT and STDERR from the Packer command stream to the console as it runs,

--- a/lib/pack_rb/executor.rb
+++ b/lib/pack_rb/executor.rb
@@ -10,13 +10,15 @@ module PackRb
     # prone to deadlocking if large chunks of data are written to the pipes.
     #
     # @param cmd [String] command to run
+    # @param tpl [String] the template content
     # @return [Array] - out_err [String], exit code [Fixnum]
-    def self.run_cmd_stream_output(cmd)
+    def self.run_cmd_stream_output(cmd, tpl)
       old_sync = $stdout.sync
       $stdout.sync = true
       all_out_err = ''
       exit_status = nil
       Open3.popen2e(cmd) do |stdin, stdout_and_err, wait_thread|
+        stdin.write(tpl)
         stdin.close_write
         begin
           while (line = stdout_and_err.gets)

--- a/lib/pack_rb/executor.rb
+++ b/lib/pack_rb/executor.rb
@@ -2,46 +2,36 @@ require 'open3'
 
 module PackRb
   class Executor
-    # popen3 wrapper to simultaneously stream command output to the
-    # appropriate file descriptor, and capture it.
+    # popen2e wrapper to simultaneously stream command output and capture it.
+    #
+    # STDOUT and STDERR will be combined to the same stream, and returned as one
+    # string. This is because there doesn't seem to be a safe, cross-platform
+    # way to both capture and stream STDOUT and STDERR separately that isn't
+    # prone to deadlocking if large chunks of data are written to the pipes.
     #
     # @param cmd [String] command to run
-    # @param tpl [String] the template content
-    # @return [Array] - stdout [String], stderr [String], exit code [Fixnum]
-    def self.run_cmd_stream_output(cmd, tpl)
-      all_out = ''
-      all_err = ''
+    # @return [Array] - out_err [String], exit code [Fixnum]
+    def self.run_cmd_stream_output(cmd)
+      old_sync = $stdout.sync
+      $stdout.sync = true
+      all_out_err = ''
       exit_status = nil
-      Open3.popen3(cmd) do |stdin, stdout, stderr, wait_thread|
-        stdin.write(tpl)
+      Open3.popen2e(cmd) do |stdin, stdout_and_err, wait_thread|
         stdin.close_write
         begin
-          files = [stdout, stderr]
-          until files.find { |f| !f.eof }.nil?
-            ready = IO.select(files)
-            next unless ready
-            readable = ready[0]
-            readable.each do |f|
-              begin
-                data = f.read_nonblock(512)
-                if f.fileno == stdout.fileno
-                  puts data
-                  all_out << data
-                else
-                  STDERR.puts data
-                  all_err << data
-                end
-              rescue EOFError
-                nil
-              end
-            end
+          while (line = stdout_and_err.gets)
+            puts line
+            all_out_err << line
           end
         rescue IOError => e
           STDERR.puts "IOError: #{e}"
         end
         exit_status = wait_thread.value.exitstatus
       end
-      [all_out, all_err, exit_status]
+      # rubocop:disable Style/RedundantReturn
+      $stdout.sync = old_sync
+      return all_out_err, exit_status
+      # rubocop:enable Style/RedundantReturn
     end
   end
 end

--- a/lib/pack_rb/sub_commands.rb
+++ b/lib/pack_rb/sub_commands.rb
@@ -20,7 +20,7 @@ module PackRb
     #
     # @param opts [Hash] options passed to the Packer class
     #
-    # @return [Array] - stdout [String], stderr [String], exit code [Fixnum]
+    # @return [Array] - stdout_and_err [String], exit code [Fixnum]
     def execute(opts)
       cmd = opts[:cmd]
       tpl = opts[:tpl]

--- a/spec/pack_rb/sub_commands_spec.rb
+++ b/spec/pack_rb/sub_commands_spec.rb
@@ -37,7 +37,7 @@ module PackRb
 
       it 'runs the provided command using run_cmd_stream_output' do
         allow(PackRb::Executor).to receive(:run_cmd_stream_output)
-          .and_return(['out', 'err', 0])
+          .and_return(['out_and_err', 0])
         expect(PackRb::Executor).to receive(:run_cmd_stream_output).once
           .with("#{cmd} -", json)
         subject.execute(cmd: cmd, tpl: json)
@@ -45,8 +45,8 @@ module PackRb
 
       it 'returns the stdout, stderr and exit code' do
         allow(PackRb::Executor).to receive(:run_cmd_stream_output)
-          .and_return(['out', 'err', 0])
-        expect(subject.execute(cmd: cmd, tpl: json)).to eq(['out', 'err', 0])
+          .and_return(['out_and_err', 0])
+        expect(subject.execute(cmd: cmd, tpl: json)).to eq(['out_and_err', 0])
       end
     end
   end


### PR DESCRIPTION
The current popen3-based implementation of run_cmd_stream_output is vulnerable to deadlocks if one pipe (out or err) receives enough data to fill it while the other is still being read and written to console.

The best alternative I could come up with is captured here - combine STDOUT and STDERR.
